### PR TITLE
Fix curl download flag

### DIFF
--- a/README
+++ b/README
@@ -13,7 +13,7 @@ yum.repos.d directories for CentOS (and perhaps others)
 
 == Installing the repo:
 
-bash < <( curl http://github.com/dayne/yum/raw/master/tools/sysconfig.sh )
+bash < <( curl -L http://github.com/dayne/yum/raw/master/tools/sysconfig.sh )
 
   * pull down the repository
     > svn co http://svn.github.com/dayne/yum


### PR DESCRIPTION
Curl now requires to have `-L` (location) flag. More info at [here](https://man7.org/linux/man-pages/man1/curl.1.html).